### PR TITLE
Updating microcode doesnt actually enable unless you also enable redist firmware

### DIFF
--- a/configuration/system.nix
+++ b/configuration/system.nix
@@ -31,6 +31,7 @@
     [ { device = "/dev/disk/by-label/SWAP"; }
     ];
 
+  hardware.enableRedistributableFirmware = true;
   hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
   hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
 }


### PR DESCRIPTION
Redistributable Firmware